### PR TITLE
Enable 'rekey' to prevent the connection loss from 'ISAKMP SA expired'

### DIFF
--- a/ipsec.conf
+++ b/ipsec.conf
@@ -4,7 +4,7 @@ conn L2TP-PSK
     authby=secret
     pfs=no
     auto=add
-    rekey=no
+    rekey=yes
     left=%defaultroute
     type=transport
     leftprotoport=17/1701


### PR DESCRIPTION
fixes #8 